### PR TITLE
Fix trailing spaces in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,2 +1,2 @@
 # GDTFComparer
-A Simple script to compare GDTF files 
+A Simple script to compare GDTF files


### PR DESCRIPTION
## Summary
- delete trailing spaces

## Testing
- `grep -n "[ ]$" README.md`

------
https://chatgpt.com/codex/tasks/task_e_683f618c41e08326925bd7e54672c0e9