### PR TITLE
Handle GDTF extraction and parsing errors

### DIFF
--- a/BEtheLD
+++ b/BEtheLD
@@ -135,8 +135,12 @@ def parse_gdtf(file_path: str) -> Dict[str, Any]:
         # Extract the GDTF file
         temp_zip_path = os.path.join(temp_dir, "temp_gdtf.zip")
         shutil.copyfile(file_path, temp_zip_path)
-        with zipfile.ZipFile(temp_zip_path, "r") as zip_ref:
-            zip_ref.extractall(temp_dir)
+        try:
+            with zipfile.ZipFile(temp_zip_path, "r") as zip_ref:
+                zip_ref.extractall(temp_dir)
+        except zipfile.BadZipFile:
+            messagebox.showerror("Error", "The selected file is not a valid GDTF archive.")
+            return {}
 
         # Locate and parse description.xml
         description_path = None
@@ -151,7 +155,11 @@ def parse_gdtf(file_path: str) -> Dict[str, Any]:
         if not description_path:
             return {}
 
-        tree = ET.parse(description_path)
+        try:
+            tree = ET.parse(description_path)
+        except ET.ParseError:
+            messagebox.showerror("Error", "description.xml could not be parsed.")
+            return {}
         root = tree.getroot()
 
         # Extract relevant attributes


### PR DESCRIPTION
## Summary
- improve error handling in `parse_gdtf`
- show message boxes for invalid zip archives or malformed XML

## Testing
- `python -m py_compile BEtheLD`


------
https://chatgpt.com/codex/tasks/task_e_683f61920c2c83269ec45c77cdfc6472