### PR TITLE
Add Blender addon skeleton and improve GDTF parser

### DIFF
--- a/BEtheLD
+++ b/BEtheLD
@@ -5,7 +5,7 @@ from typing import Dict, Any
 import shutil
 import tempfile
 import tkinter as tk
-from tkinter import filedialog, ttk, messagebox
+from tkinter import filedialog, ttk
 
 
 class GDTFComparerApp:
@@ -147,9 +147,9 @@ def parse_gdtf(file_path: str) -> Dict[str, Any]:
         try:
             with zipfile.ZipFile(temp_zip_path, "r") as zip_ref:
                 zip_ref.extractall(temp_dir)
-        except zipfile.BadZipFile:
-            messagebox.showerror("Error", "The selected file is not a valid GDTF archive.")
-            return {}
+        except zipfile.BadZipFile as exc:
+            # Propagate the error so callers can handle it (e.g. tests)
+            raise exc
 
         # Locate and parse description.xml
         description_path = None
@@ -166,9 +166,9 @@ def parse_gdtf(file_path: str) -> Dict[str, Any]:
 
         try:
             tree = ET.parse(description_path)
-        except ET.ParseError:
-            messagebox.showerror("Error", "description.xml could not be parsed.")
-            return {}
+        except ET.ParseError as exc:
+            # Propagate parse errors to the caller
+            raise exc
         root = tree.getroot()
 
         # Extract relevant attributes

--- a/README.md
+++ b/README.md
@@ -1,2 +1,9 @@
 # GDTFComparer
 A Simple script to compare GDTF files
+
+## Blender Addon
+
+This repository now also contains a minimal skeleton for a Blender addon that
+aims to provide support for importing MVR and GDTF files. The addon lives in the
+`blender_addon` directory and currently only defines the basic structure needed
+for a Blender add-on.

--- a/blender_addon/README.md
+++ b/blender_addon/README.md
@@ -1,0 +1,10 @@
+# Blender MVR/GDTF Addon
+
+This directory contains the starting point for a Blender addon that aims to add support
+for MVR (My Virtual Rig) and GDTF (General Device Type Format) files. The addon will
+allow Blender to import lighting setups and fixture definitions described in these
+formats.
+
+This repository currently provides only a minimal skeleton. Future work will include
+implementing operators for loading data, custom properties for fixtures, and integration
+with Blender's lighting system.

--- a/blender_addon/__init__.py
+++ b/blender_addon/__init__.py
@@ -1,0 +1,21 @@
+bl_info = {
+    "name": "MVR/GDTF Importer",
+    "author": "",
+    "version": (0, 1, 0),
+    "blender": (2, 80, 0),
+    "location": "File > Import",
+    "description": "Import MVR and GDTF files",
+    "category": "Import-Export",
+}
+
+
+def register():
+    pass
+
+
+def unregister():
+    pass
+
+
+if __name__ == "__main__":
+    register()


### PR DESCRIPTION
## Summary
- add minimal Blender addon skeleton
- document Blender addon in README
- refactor `parse_gdtf` to raise exceptions instead of using GUI dialogs
- add README for addon

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_683f6395c3808326ade3edc35cbd8ebd